### PR TITLE
Use the service pattern to access resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,25 +14,24 @@ Guava follows.  In this example, we'll construct the Beam API, and then get a
 list of all channel IDs.
 
 ```java
-// Construct the Beam API. There are no parameters.
+// Construct an instance of the Beam API such that we can query certain
+// endpoints for data.
 BeamAPI beam = new BeamAPI();
 
-// Call the #get method on a relative path, given a repsonse class.  Add a
-// callback to catch the response.
-
-Futures.addCallback(beam.get("channels", ShowChannelsResponse.class), new
-FutureCallback<ShowChannelsResponse>() {
-    // Define a method to be called on-success.
-    @Override public void onSuccess(ShowChannelsResponse response) {
-        // Here, we can handle the response that the callback provides.
-        for (BeamChannel channel : response) {
-            System.out.println(channel.id);
+// Invoke the `UsersService.class` in order to access the methods within
+// that service.  Then, assign a callback using Guava's FutureCallback
+// class so we can act on the response.
+Futures.addCallback(beam.use(UsersService.class).search("tta"), new
+FutureCallback<UserSearchResponse>() {
+    // Set up a handler for the response
+    @Override public void onSuccess(UserSearchResponse response) {
+        for (BeamUser user : response) {
+            System.out.println(user.username);
         }
     }
 
-    // Define a method to be called on-failure.
     @Override public void onFailure(Throwable throwable) {
-        throwable.printStackTrace();
+        // ...
     }
 });
 ```

--- a/src/main/java/pro/beam/api/BeamAPI.java
+++ b/src/main/java/pro/beam/api/BeamAPI.java
@@ -7,6 +7,7 @@ import com.google.gson.GsonBuilder;
 import pro.beam.api.http.BeamHttpClient;
 import pro.beam.api.services.AbstractBeamService;
 import pro.beam.api.services.ServiceManager;
+import pro.beam.api.services.impl.UsersService;
 
 import java.net.URI;
 import java.util.concurrent.Executors;
@@ -23,6 +24,8 @@ public class BeamAPI {
         this.executor = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(10));
         this.http = new BeamHttpClient(this);
         this.services = new ServiceManager();
+
+        this.register(new UsersService(this));
     }
 
     public <T extends AbstractBeamService> T get(Class<T> service) {

--- a/src/main/java/pro/beam/api/BeamAPI.java
+++ b/src/main/java/pro/beam/api/BeamAPI.java
@@ -28,7 +28,7 @@ public class BeamAPI {
         this.register(new UsersService(this));
     }
 
-    public <T extends AbstractBeamService> T get(Class<T> service) {
+    public <T extends AbstractBeamService> T use(Class<T> service) {
         return this.services.get(service);
     }
 

--- a/src/main/java/pro/beam/api/BeamAPI.java
+++ b/src/main/java/pro/beam/api/BeamAPI.java
@@ -1,106 +1,35 @@
 package pro.beam.api;
 
-import com.google.api.client.http.*;
-import com.google.api.client.http.javanet.NetHttpTransport;
-import com.google.common.util.concurrent.*;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import pro.beam.api.http.RequestType;
+import pro.beam.api.http.BeamHttpClient;
+import pro.beam.api.services.AbstractBeamService;
+import pro.beam.api.services.ServiceManager;
 
-import java.io.IOException;
 import java.net.URI;
-import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 
 public class BeamAPI {
     public static final URI BASE_PATH = URI.create("https://beam.pro/api/v1/");
 
-    protected final ListeningExecutorService executor;
-    protected final HttpRequestFactory requestFactory;
-    protected final Gson gson = new GsonBuilder().create();
+    public final Gson gson = new GsonBuilder().create();
+    public final BeamHttpClient http;
+    public final ListeningExecutorService executor;
+    protected final ServiceManager services;
 
     public BeamAPI() {
         this.executor = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(10));
-        this.requestFactory = new NetHttpTransport().createRequestFactory();
+        this.http = new BeamHttpClient(this);
+        this.services = new ServiceManager();
     }
 
-    public <T> ListenableFuture<T> get(String path, Class<T> type) {
-        return this.executor.submit(this.makeCallable(this.makeRequest(RequestType.GET, path), type));
+    public <T extends AbstractBeamService> T get(Class<T> service) {
+        return this.services.get(service);
     }
 
-    public <T> ListenableFuture<T> post(String path, Class<T> type, Object... args) {
-        return this.executor.submit(this.makeCallable(this.makeRequest(RequestType.POST, path, args), type));
-    }
-
-    public <T> ListenableFuture<T> put(String path, Class<T> type, Object... args) {
-        return this.executor.submit(this.makeCallable(this.makeRequest(RequestType.PUT, path, args), type));
-    }
-
-    public <T> ListenableFuture<T> delete(String path, Class<T> type) {
-        return this.executor.submit(this.makeCallable(this.makeRequest(RequestType.DELETE, path), type));
-    }
-
-    /**
-     * Forwards the method call to #makeRequest without any content.
-     */
-    private HttpRequest makeRequest(RequestType requestType, String path) {
-        return this.makeRequest(requestType, path, null);
-    }
-
-    /**
-     * Creates a {@link com.google.api.client.http.HttpRequest} given a type, path, and optional content.
-     *
-     * @param requestType The type of HTTP/1.1 request to make (see {@link pro.beam.api.http.RequestType}
-     *                    for more details.
-     * @param path The absolute path to direct the request at (see #buildFromRelativePath for more details)
-     * @param args The content of the request.  This parameter is optional and considered to be nullable.
-     *
-     * @return A request built from the specification above.
-     */
-    private HttpRequest makeRequest(RequestType requestType, String path, Object... args) {
-        try {
-            return this.requestFactory.buildRequest(requestType.name(),
-                                                    this.buildFromRelativePath(path),
-                                                    this.makeRequestContent(args));
-        } catch (IOException e) {
-            return null;
-        }
-    }
-
-    private HttpContent makeRequestContent(Object... args) {
-        byte[] contents = this.gson.toJson(args.length == 1 ? args[0] : args).getBytes();
-        return new ByteArrayContent("application/json", contents);
-    }
-
-    /**
-     * This public-facing method constructs a callable which has the responsibility of executing the request
-     * given, and parsing it using an instance of a GSON parser into the desired class-type,  Typically this method
-     * is used to submit a {@link java.util.concurrent.Callable} to the
-     * {@link com.google.common.util.concurrent.ListeningExecutorService} such that a callback can be fired when the
-     * request and parsing is complete.
-     *
-     * @param request The {@link com.google.api.client.http.HttpRequest} to be executed.
-     * @param type The class-type of the response body.  (See the "response" package for examples.)
-     *
-     * @return The callable as described above.
-     */
-    private <T> Callable<T> makeCallable(final HttpRequest request, final Class<T> type) {
-        return new Callable<T>() {
-            @Override public T call() throws Exception {
-                HttpResponse response = request.execute();
-                return BeamAPI.this.gson.fromJson(response.parseAsString(), type);
-            }
-        };
-    }
-
-    /**
-     * Takes a relative path and makes it absolute with respect to the root of the API.
-     *
-     * @param path The relative path (ex., "channels/")
-     *
-     * @return The absolute resolved path as a GenericUrl.
-     */
-    private GenericUrl buildFromRelativePath(String path) {
-        return new GenericUrl(BASE_PATH.resolve(path));
+    public boolean register(AbstractBeamService service) {
+        return this.services.register(service);
     }
 }

--- a/src/main/java/pro/beam/api/http/BeamHttpClient.java
+++ b/src/main/java/pro/beam/api/http/BeamHttpClient.java
@@ -1,0 +1,110 @@
+package pro.beam.api.http;
+
+import com.google.api.client.http.*;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonObjectParser;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import pro.beam.api.BeamAPI;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+
+public class BeamHttpClient {
+    protected final BeamAPI beam;
+    protected final HttpRequestFactory requestFactory;
+
+    public BeamHttpClient(BeamAPI beam) {
+        this.beam = beam;
+        this.requestFactory = new NetHttpTransport().createRequestFactory(new HttpRequestInitializer() {
+            @Override public void initialize(HttpRequest request) throws IOException {
+                request.setParser(new JsonObjectParser(new GsonFactory()));
+            }
+        });
+    }
+
+    public <T> ListenableFuture<T> get(String path, Class<T> type) {
+        return this.executor().submit(this.makeCallable(this.makeRequest(RequestType.GET, path), type));
+    }
+
+    public <T> ListenableFuture<T> post(String path, Class<T> type, Object... args) {
+        return this.executor().submit(this.makeCallable(this.makeRequest(RequestType.POST, path, args), type));
+    }
+
+    public <T> ListenableFuture<T> put(String path, Class<T> type, Object... args) {
+        return this.executor().submit(this.makeCallable(this.makeRequest(RequestType.PUT, path, args), type));
+    }
+
+    public <T> ListenableFuture<T> delete(String path, Class<T> type) {
+        return this.executor().submit(this.makeCallable(this.makeRequest(RequestType.DELETE, path), type));
+    }
+
+    /**
+     * Forwards the method call to #makeRequest without any content.
+     */
+    private HttpRequest makeRequest(RequestType requestType, String path) {
+        return this.makeRequest(requestType, path, null);
+    }
+
+    /**
+     * Creates a {@link com.google.api.client.http.HttpRequest} given a type, path, and optional content.
+     *
+     * @param requestType The type of HTTP/1.1 request to make (see {@link pro.beam.api.http.RequestType}
+     *                    for more details.
+     * @param path The absolute path to direct the request at (see #buildFromRelativePath for more details)
+     * @param args The content of the request.  This parameter is optional and considered to be nullable.
+     *
+     * @return A request built from the specification above.
+     */
+    private HttpRequest makeRequest(RequestType requestType, String path, Object... args) {
+        try {
+            return this.requestFactory.buildRequest(requestType.name(),
+                    this.buildFromRelativePath(path),
+                    this.makeRequestContent(args));
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private HttpContent makeRequestContent(Object... args) {
+        byte[] contents = this.beam.gson.toJson(args.length == 1 ? args[0] : args).getBytes();
+        return new ByteArrayContent("application/json", contents);
+    }
+
+    /**
+     * This public-facing method constructs a callable which has the responsibility of executing the request
+     * given, and parsing it using an instance of a GSON parser into the desired class-type,  Typically this method
+     * is used to submit a {@link java.util.concurrent.Callable} to the
+     * {@link com.google.common.util.concurrent.ListeningExecutorService} such that a callback can be fired when the
+     * request and parsing is complete.
+     *
+     * @param request The {@link com.google.api.client.http.HttpRequest} to be executed.
+     * @param type The class-type of the response body.  (See the "response" package for examples.)
+     *
+     * @return The callable as described above.
+     */
+    private <T> Callable<T> makeCallable(final HttpRequest request, final Class<T> type) {
+        return new Callable<T>() {
+            @Override public T call() throws Exception {
+                HttpResponse response = request.execute();
+                return BeamHttpClient.this.beam.gson.fromJson(response.parseAsString(), type);
+            }
+        };
+    }
+
+    /**
+     * Takes a relative path and makes it absolute with respect to the root of the API.
+     *
+     * @param path The relative path (ex., "channels/")
+     *
+     * @return The absolute resolved path as a GenericUrl.
+     */
+    private GenericUrl buildFromRelativePath(String path) {
+        return new GenericUrl(BeamAPI.BASE_PATH.resolve(path));
+    }
+
+    private ListeningExecutorService executor() {
+        return this.beam.executor;
+    }
+}

--- a/src/main/java/pro/beam/api/http/RequestType.java
+++ b/src/main/java/pro/beam/api/http/RequestType.java
@@ -1,5 +1,5 @@
 package pro.beam.api.http;
 
 public enum RequestType {
-    GET, POST, PUT, DELETE;
+    GET, POST, PUT, DELETE
 }

--- a/src/main/java/pro/beam/api/response/users/UserSearchResponse.java
+++ b/src/main/java/pro/beam/api/response/users/UserSearchResponse.java
@@ -1,0 +1,10 @@
+package pro.beam.api.response.users;
+
+import java.util.ArrayList;
+
+public class UserSearchResponse extends ArrayList<UserSearchResponse.User> {
+    public static class User {
+        public String username;
+        public int id;
+    }
+}

--- a/src/main/java/pro/beam/api/response/users/UserSearchResponse.java
+++ b/src/main/java/pro/beam/api/response/users/UserSearchResponse.java
@@ -1,10 +1,8 @@
 package pro.beam.api.response.users;
 
+import pro.beam.api.resource.BeamUser;
+
 import java.util.ArrayList;
 
-public class UserSearchResponse extends ArrayList<UserSearchResponse.User> {
-    public static class User {
-        public String username;
-        public int id;
-    }
+public class UserSearchResponse extends ArrayList<BeamUser> {
 }

--- a/src/main/java/pro/beam/api/services/AbstractBeamService.java
+++ b/src/main/java/pro/beam/api/services/AbstractBeamService.java
@@ -1,0 +1,11 @@
+package pro.beam.api.services;
+
+import pro.beam.api.BeamAPI;
+
+public abstract class AbstractBeamService {
+    protected final BeamAPI beam;
+
+    public AbstractBeamService(BeamAPI beam) {
+        this.beam = beam;
+    }
+}

--- a/src/main/java/pro/beam/api/services/AbstractHTTPService.java
+++ b/src/main/java/pro/beam/api/services/AbstractHTTPService.java
@@ -4,27 +4,35 @@ import com.google.common.util.concurrent.ListenableFuture;
 import pro.beam.api.BeamAPI;
 import pro.beam.api.http.BeamHttpClient;
 
+import java.util.Map;
+
 public abstract class AbstractHTTPService extends AbstractBeamService {
     protected final BeamHttpClient http;
+    protected final String path;
 
-    public AbstractHTTPService(BeamAPI beam) {
+    public AbstractHTTPService(BeamAPI beam, String path) {
         super(beam);
-        this.http = this.beam.http();
+        this.http = this.beam.http;
+        this.path = path;
     }
 
-    public <T> ListenableFuture<T> get(String path, Class<T> type) {
-        return this.http.get(path, type);
+    protected <T> ListenableFuture<T> get(String path, Class<T> type, Map<String, Object> parameters) {
+        return this.http.get(this.path(path), type, parameters);
     }
 
-    public <T> ListenableFuture<T> post(String path, Class<T> type, Object... args) {
-        return this.http.post(path, type, args);
+    protected <T> ListenableFuture<T> post(String path, Class<T> type, Object... args) {
+        return this.http.post(this.path(path), type, args);
     }
 
-    public <T> ListenableFuture<T> put(String path, Class<T> type, Object... args) {
-        return this.http.put(path, type, args);
+    protected <T> ListenableFuture<T> put(String path, Class<T> type, Object... args) {
+        return this.http.put(this.path(path), type, args);
     }
 
-    public <T> ListenableFuture<T> delete(String path, Class<T> type) {
-        return this.http.delete(path, type);
+    protected <T> ListenableFuture<T> delete(String path, Class<T> type) {
+        return this.http.delete(this.path(path), type);
+    }
+
+    public String path(String relative) {
+        return BeamAPI.BASE_PATH.resolve(this.path + "/" + relative).toString();
     }
 }

--- a/src/main/java/pro/beam/api/services/AbstractHTTPService.java
+++ b/src/main/java/pro/beam/api/services/AbstractHTTPService.java
@@ -1,0 +1,19 @@
+package pro.beam.api.services;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import pro.beam.api.BeamAPI;
+import pro.beam.api.http.RequestType;
+
+import java.io.IOException;
+
+public abstract class AbstractHTTPService extends AbstractBeamService {
+    public AbstractHTTPService(BeamAPI beam) {
+        super(beam);
+    }
+
+    public <T> ListenableFuture<T> get(String path, Class<T> type) throws IOException {
+        return this.beam.get(path, type);
+    }
+
+    public
+}

--- a/src/main/java/pro/beam/api/services/AbstractHTTPService.java
+++ b/src/main/java/pro/beam/api/services/AbstractHTTPService.java
@@ -2,18 +2,29 @@ package pro.beam.api.services;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import pro.beam.api.BeamAPI;
-import pro.beam.api.http.RequestType;
-
-import java.io.IOException;
+import pro.beam.api.http.BeamHttpClient;
 
 public abstract class AbstractHTTPService extends AbstractBeamService {
+    protected final BeamHttpClient http;
+
     public AbstractHTTPService(BeamAPI beam) {
         super(beam);
+        this.http = this.beam.http();
     }
 
-    public <T> ListenableFuture<T> get(String path, Class<T> type) throws IOException {
-        return this.beam.get(path, type);
+    public <T> ListenableFuture<T> get(String path, Class<T> type) {
+        return this.http.get(path, type);
     }
 
-    public
+    public <T> ListenableFuture<T> post(String path, Class<T> type, Object... args) {
+        return this.http.post(path, type, args);
+    }
+
+    public <T> ListenableFuture<T> put(String path, Class<T> type, Object... args) {
+        return this.http.put(path, type, args);
+    }
+
+    public <T> ListenableFuture<T> delete(String path, Class<T> type) {
+        return this.http.delete(path, type);
+    }
 }

--- a/src/main/java/pro/beam/api/services/ServiceManager.java
+++ b/src/main/java/pro/beam/api/services/ServiceManager.java
@@ -1,0 +1,35 @@
+package pro.beam.api.services;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+public class ServiceManager {
+    protected final Set<AbstractBeamService> services = new HashSet<>();
+
+    @SuppressWarnings("unchecked")
+    public <T extends AbstractBeamService> T get(Class<T> type) {
+        for (AbstractBeamService service : this.services) {
+            if (service.getClass() == type) {
+                return (T) service;
+            }
+        }
+
+        return null;
+    }
+
+    public boolean register(AbstractBeamService service) {
+        return this.services.add(service);
+    }
+
+    public boolean unregister(AbstractBeamService service) {
+        return this.services.remove(service);
+    }
+
+    public void unregisterAll() {
+        for (Iterator<AbstractBeamService> it = this.services.iterator(); it.hasNext(); ) {
+            AbstractBeamService service = it.next();
+            this.unregister(service);
+        }
+    }
+}

--- a/src/main/java/pro/beam/api/services/impl/UsersService.java
+++ b/src/main/java/pro/beam/api/services/impl/UsersService.java
@@ -1,0 +1,26 @@
+package pro.beam.api.services.impl;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ListenableFuture;
+import pro.beam.api.BeamAPI;
+import pro.beam.api.response.users.UserSearchResponse;
+import pro.beam.api.services.AbstractHTTPService;
+
+import java.util.Map;
+
+public class UsersService extends AbstractHTTPService {
+    public UsersService(BeamAPI beam) {
+        super(beam, "users");
+    }
+
+    public ListenableFuture<UserSearchResponse> search(String query) {
+        if (query != null && query.length() < 3) {
+            throw new IllegalArgumentException("unable to preform search with query less than 3 characters (was "+query.length()+")");
+        } else {
+            Map<String, Object> args = new ImmutableMap.Builder<String, Object>()
+                                      .put("query", query).build();
+
+            return this.get("search", UserSearchResponse.class, args);
+        }
+    }
+}


### PR DESCRIPTION
- Implement the service pattern
- Allow query-string parameters to GET requests
- Implement the users search endpoint.

Example:

```java
BeamAPI beam = new BeamAPI();
Futures.addCallback(beam.use(UserService.class).search("query"), ...);

// ...
```

\- vs -

```java
BeamAPI beam = new BeamAPI();
Futures.addCallback(beam.get("users/search?query="+query), ...);

// ...
```